### PR TITLE
Fix Registration Check

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -36,7 +36,7 @@ def register():
     print("Posted to /register")
     data = request.get_json()
     #Check if email is already in use
-    check_candidate = Candidate.query.filter_by(email=data['email'])
+    check_candidate = Candidate.query.filter_by(email=data['email']).first()
     if(check_candidate is not None):
       return jsonify({'status': 'Failure', 'error': 'Email is already in use. Please use another'})
     candidate = Candidate(candidate_id=uuid.uuid4().hex,


### PR DESCRIPTION
This fixes a bug in `/registration` where adding a new user on a fresh DB would always return "email is always in use".

Without a `first()` or `all()` at the end `check_candidate` will never evaluate to None, even if there's no matching email.

![screenshot from 2018-04-01 14-31-12](https://user-images.githubusercontent.com/5942769/38177650-986a9e62-35b9-11e8-81d3-d09ad7a3def7.png)

